### PR TITLE
Add callback on deep sleep enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ class ModuleCallbacks: public SailtrackModuleCallbacks {
         // Add here any extra log information.
     }
 
+    void onEnterDeepSleep() {
+        // Called when the module is about to enter deep sleep.
+        // Add here any extra energy-saving task.
+    }
+
     void onStatusMessage(JsonObject status) {
         // Called when a new status message is being published to the MQTT network.
         // Add here any extra status information (e.g. battery voltage) by adding it to the `status` object.

--- a/include/SailtrackModuleCallbacks.h
+++ b/include/SailtrackModuleCallbacks.h
@@ -26,6 +26,11 @@ class SailtrackModuleCallbacks {
          *      information of the module.
          */
         virtual void onStatusPublish(JsonObject status) {}
+
+        /**
+         * Called when the module is about to enter deep sleep.
+         */
+        virtual void onEnterDeepSleep() {}
 };
 
 #endif

--- a/src/SailtrackModule.cpp
+++ b/src/SailtrackModule.cpp
@@ -53,6 +53,7 @@ void SailtrackModule::beginWifi(IPAddress ip) {
         log_i("Impossible to connect to '%s'", STM_WIFI_AP_SSID);
         log_i("Going to deep sleep, goodnight...");
         log_printf("\n");
+        if (callbacks) callbacks->onEnterDeepSleep();
         ESP.deepSleep(STM_WIFI_SLEEP_DURATION_US);
     }
 


### PR DESCRIPTION
This PR adds the `onEnterDeepSleep()` callback, called when the module is about to enter deep sleep. This callback can be useful for those scenarios where extra energy-saving tasks need to be performed before entering deep sleep.